### PR TITLE
WFOF-237 Add view for identifying new subscribers

### DIFF
--- a/vw_new_subscribers.sql
+++ b/vw_new_subscribers.sql
@@ -1,0 +1,32 @@
+DROP VIEW IF EXISTS finance_metrics.new_subs;
+CREATE VIEW finance_metrics.new_subs AS 
+
+
+WITH first_sub AS (
+    SELECT
+        customer_id,
+        MIN(DATE(created)) AS first_sub_created
+    FROM all_stripe.subscription_history
+    WHERE status = 'active'
+    GROUP BY 1
+),
+
+first_charge AS (
+    SELECT 
+        customer_id,
+        MIN(DATE(created)) AS first_charge_created
+    FROM all_stripe.charge
+    WHERE status = 'succeeded'
+    GROUP BY 1
+)
+
+SELECT
+    fs.customer_id,
+    fs.first_sub_created
+FROM first_sub AS fs
+LEFT JOIN first_charge AS fc
+    ON fs.customer_id = fc.customer_id
+       -- Only join if the charge was >7 days before subscription
+    AND fc.first_charge_created <= DATE_SUB(fs.first_sub_created, INTERVAL 7 DAY)
+WHERE 
+    fc.first_charge_created IS NULL -- Only keep those with NO charge >7 days before sub


### PR DESCRIPTION
Introduces the finance_metrics.new_subs view to identify customers whose first successful subscription does not follow a successful charge more than 7 days prior. This helps in isolating genuinely new subscribers for financial metrics.