### PR TITLE
WFOF-243 Refactor monthly contribution margin view for clarity

### DIFF
--- a/vw_monthly_contribution_margin.sql
+++ b/vw_monthly_contribution_margin.sql
@@ -1,156 +1,170 @@
+-- Drop the view if it already exists to ensure a clean slate for re-creation
 DROP VIEW IF EXISTS finance_metrics.monthly_contribution_margin;
-CREATE VIEW finance_metrics.monthly_contribution_margin AS 
+
+-- Create the new view with all logic and reconciliation
+CREATE VIEW finance_metrics.monthly_contribution_margin AS
 
 WITH
 
--- 1. RAW: compute all scalar fields + acq_month per customer, and adjust cogs for refunds
+-- ========================================================
+-- Step 1: Source Aggregations with Standardised Keys
+-- ========================================================
+
+-- Raw transaction data: apply lowercasing and 'N/A' as default for country/condition
 raw_data AS (
   SELECT
-    region AS country,
-    DATE_TRUNC(purchase_date, MONTH) AS date,
-    purchase_type,
-    billing_reason,
-    COALESCE(new_existing, 'New') AS new_existing,
-    sales_channel,
-    COALESCE(condition, 'N/A') AS condition,
-    customer_id,
-    charge_id,
-    currency,
-    COALESCE(line_item_amount_usd, total_charge_amount_usd) AS amount,
-    cogs * quantity AS cogs,
-    packaging,
-    cashback,
-    amount_refunded_usd,
-    fee_rate,
-    gst_vat,
-    -- first purchase month per customer
-    MIN(DATE_TRUNC(purchase_date, MONTH)) OVER (PARTITION BY customer_id) AS acq_month
+    COALESCE(LOWER(region), 'N/A') AS country,                       -- Standardise country names and fill NULLs
+    DATE_TRUNC(purchase_date, MONTH) AS date,                        -- Truncate purchase date to month for reporting
+    COALESCE(condition, 'N/A') AS condition,                         -- Standardise condition field, fill NULLs
+    COALESCE(line_item_amount_usd, total_charge_amount_usd) AS amount,-- Fallback if line item amount is missing
+    cogs * quantity AS cogs,                                         -- Calculate COGS by multiplying by quantity
+    packaging,                                                       -- Packaging cost per transaction
+    cashback,                                                        -- Cashback or rebate amount, if any
+    amount_refunded_usd,                                             -- USD value refunded
+    fee_rate,                                                        -- Gateway fee rate for this transaction
+    gst_vat,                                                         -- GST/VAT percentage, if any
+    charge_id                                                        -- Unique identifier for the charge
   FROM finance_metrics.contribution_margin
 ),
 
--- 2. BASE: aggregate all the sums and counts, now that acq_month is just a column. 
-base AS (
-	SELECT
-		country,
-		date,
-		purchase_type,
-		billing_reason,
-		new_existing,
-		sales_channel,
-		condition,
-		acq_month,
-		customer_id,
-		currency,
-		SUM(amount) AS amount,
-		SUM(COALESCE(cogs, 0) * (1 - SAFE_DIVIDE(amount_refunded_usd, amount))) AS cogs,
-		SUM(packaging) AS packaging,
-		SUM(cashback) AS cashback,
-		SUM((amount - amount_refunded_usd) * (1 - 1 / (1 + gst_vat))) AS tax_paid_usd,
-		SUM(amount * fee_rate) AS gateway_fees,
-		SUM(amount_refunded_usd) AS refunds,
-		COUNT(DISTINCT charge_id) AS n_orders
-	FROM raw_data
-	GROUP BY 1,2,3,4,5,6,7,8,9,10
+-- Aggregate sales/transactional data to monthly, country, and condition level
+sales_agg AS (
+  SELECT
+    date,
+    country,
+    condition,
+    SUM(amount) AS amount,   -- Total sales amount (USD)
+    SUM(COALESCE(cogs, 0) * (1 - SAFE_DIVIDE(amount_refunded_usd, amount))) AS cogs, -- Net COGS after refund allocation
+    SUM(packaging) AS packaging,    -- Total packaging costs
+    SUM(cashback) AS cashback,      -- Total cashback issued
+    SUM((amount - amount_refunded_usd) * (1 - 1 / (1 + gst_vat))) AS tax_paid_usd, -- Estimated tax paid, net of refunds
+    SUM(amount * fee_rate) AS gateway_fees,   -- Sum of all gateway (payment processor) fees
+    SUM(amount_refunded_usd) AS refunds,      -- Total refunded amount
+    COUNT(DISTINCT charge_id) AS n_orders     -- Number of unique orders/charges
+  FROM raw_data
+  GROUP BY 1,2,3
 ),
 
--- 3. Delivery costs by month & country
-delivery AS (
-	SELECT
-		DATE_TRUNC(dc.date, MONTH) AS date,
-		LOWER(dc.country) AS country,
-		SUM(dc.cost / fx.fx_to_usd) AS total_delivery_cost
-	FROM google_sheets.delivery_cost dc
-	JOIN ref.fx_rates AS fx
-		ON LOWER(dc.currency) = fx.currency
-	GROUP BY 1,2
+-- Marketing spend aggregation by date, country, and condition
+marketing_agg AS (
+  SELECT
+    DATE_TRUNC(date, MONTH) AS date,
+    COALESCE(LOWER(country_code), 'N/A') AS country,    -- Standardise country and fill blanks
+    COALESCE(condition, 'N/A') AS condition,            -- Standardise condition and fill blanks
+    SUM(cost_usd) AS marketing_cost                     -- Total marketing spend (USD)
+  FROM cac.marketing_spend
+  GROUP BY 1,2,3
 ),
 
--- 4. Marketing costs by month, country & condition
-marketing AS (
-	SELECT
-		DATE_TRUNC(DATE, MONTH) AS date,
-		LOWER(country_code) AS country,
-		COALESCE(condition, 'N/A') AS condition,
-		SUM(cost_usd) AS total_marketing_cost
-	FROM cac.marketing_spend
-	GROUP BY 1,2,3
+-- Delivery cost aggregated by month/country; condition always set to 'N/A'
+delivery_agg AS (
+  SELECT
+    DATE_TRUNC(dc.date, MONTH) AS date,
+    COALESCE(LOWER(dc.country), 'N/A') AS country,
+    'N/A' AS condition,                              -- Delivery is not split by condition
+    SUM(dc.cost / fx.fx_to_usd) AS delivery_cost     -- Convert local delivery cost to USD
+  FROM google_sheets.delivery_cost dc
+  JOIN ref.fx_rates AS fx ON LOWER(dc.currency) = fx.currency
+  GROUP BY 1,2,3
 ),
 
--- 5. OPEX (teleconsult, dispensing, operating, staff)
-opex AS (
-	SELECT
-		DATE_TRUNC(o.date, MONTH) AS date,
-		LOWER(o.country) AS country,
-		- SUM(o.teleconsultation_fees / fx.fx_to_usd) AS teleconsultation_fees,
-		- SUM(o.dispensing_fees / fx.fx_to_usd) AS dispensing_fees,
-		- SUM(o.operating_expense / fx.fx_to_usd) AS operating_expense,
-		- SUM(o.staff_cost / fx.fx_to_usd) AS staff_cost
-	FROM google_sheets.opex o
-	JOIN  ref.fx_rates AS fx 
-		ON LOWER(o.currency) = fx.currency
-	GROUP BY 1,2
+-- Operating expenses aggregated by month/country; condition always set to 'N/A'
+opex_agg AS (
+  SELECT
+    DATE_TRUNC(o.date, MONTH) AS date,
+    COALESCE(LOWER(o.country), 'N/A') AS country,
+    'N/A' AS condition,                                 -- OPEX is not split by condition
+    -SUM(o.teleconsultation_fees / fx.fx_to_usd) AS teleconsultation_fees, -- All expenses as negatives for consistency
+    -SUM(o.dispensing_fees / fx.fx_to_usd) AS dispensing_fees,
+    -SUM(o.operating_expense / fx.fx_to_usd) AS operating_expense,
+    -SUM(o.staff_cost / fx.fx_to_usd) AS staff_cost
+  FROM google_sheets.opex o
+  JOIN ref.fx_rates AS fx ON LOWER(o.currency) = fx.currency
+  GROUP BY 1,2,3
 ),
 
--- put it all together, and set COGS to teleconsult fee expense for Services transactions
-base_with_opex AS (
-	SELECT
-		b.* EXCEPT (cogs),
-		CASE 
-			WHEN b.condition = 'Services' THEN o.teleconsultation_fees * b.amount / SUM(b.amount) OVER (PARTITION BY b.country, b.date, b.condition)
-			ELSE b.cogs
-			END AS cogs,
-			
-		-- Prorated delivery cost
-		SAFE_DIVIDE(
-			b.amount,
-			SUM(b.amount) OVER (PARTITION BY b.date, b.country)
-		) * COALESCE(d.total_delivery_cost, 0) AS delivery_cost, 
-	  
-	  -- Prorated marketing cost
-		SAFE_DIVIDE(
-			b.amount,
-			SUM(b.amount) OVER (PARTITION BY b.date, b.country, b.condition)
-		) * COALESCE(m.total_marketing_cost, 0) AS marketing_cost,
-	  
-	  -- Prorated OPEX lines
-		SAFE_DIVIDE(
-			b.amount,
-			SUM(b.amount) OVER (PARTITION BY b.date, b.country)
-		) * COALESCE(o.dispensing_fees, 0) AS dispensing_fees,
-	  
-		SAFE_DIVIDE(
-			b.amount,
-			SUM(b.amount) OVER (PARTITION BY b.date, b.country)
-		) * COALESCE(o.operating_expense, 0) AS operating_expense,
-		SAFE_DIVIDE(
-			b.amount,
-			SUM(b.amount) OVER (PARTITION BY b.date, b.country)
-		) * COALESCE(o.staff_cost, 0) AS staff_cost
-	FROM base AS b
-	LEFT JOIN delivery AS d 
-		ON b.date = d.date
-	  	AND LOWER(b.country) = d.country
-	LEFT JOIN marketing AS m 
-		ON b.date = m.date
-		AND LOWER(b.country) = m.country
-		AND b.condition = m.condition
-	LEFT JOIN opex AS o 
-		ON b.date = o.date
-		AND LOWER(b.country) = o.country
+-- ========================================================
+-- Step 2: Build 'all_keys' (all valid combinations of date, country, condition)
+-- This ensures that every possible reporting key is present in the output,
+-- even if one or more source tables are missing a given key.
+-- ========================================================
+all_keys AS (
+  SELECT DISTINCT date, country, condition FROM sales_agg
+  UNION DISTINCT
+  SELECT DISTINCT date, country, condition FROM marketing_agg
+  UNION DISTINCT
+  SELECT DISTINCT date, country, condition FROM delivery_agg
+  UNION DISTINCT
+  SELECT DISTINCT date, country, condition FROM opex_agg
 )
 
--- now select final output
--- add coalesce statements for NULL
+-- ========================================================
+-- Step 3: Final Output - LEFT JOIN all sources to all_keys
+-- Ensures complete coverage and alignment, prevents accidental dropping of
+-- orphan rows from any source.
+-- ========================================================
 SELECT
-	bpo.* EXCEPT(amount, packaging, delivery_cost, gateway_fees),
-	amount AS gross_revenue,
-	amount - refunds - tax_paid_usd AS net_revenue,
-	COALESCE(gateway_fees, 0) AS gateway_fees,
-	COALESCE(packaging, 0) AS packaging,
-	COALESCE(delivery_cost, 0) AS delivery_cost,
-	amount - refunds - tax_paid_usd - cogs - COALESCE(dispensing_fees, 0) AS gross_profit,
-	amount - refunds - tax_paid_usd - cogs - COALESCE(dispensing_fees, 0) - COALESCE(packaging, 0) - COALESCE(delivery_cost, 0) - COALESCE(gateway_fees, 0) AS cm2,
-	amount - refunds - tax_paid_usd - cogs - COALESCE(dispensing_fees, 0) - COALESCE(packaging, 0) - COALESCE(delivery_cost, 0) - COALESCE(gateway_fees, 0) - marketing_cost AS cm3,
-	amount - refunds - tax_paid_usd - cogs - COALESCE(dispensing_fees, 0) - COALESCE(packaging, 0) - COALESCE(delivery_cost, 0) - COALESCE(gateway_fees, 0) - marketing_cost  - operating_expense - staff_cost AS ebitda
+  k.date,
+  k.country,
+  k.condition,
 
-FROM base_with_opex AS bpo
+  -- Base metrics from sales
+  COALESCE(s.amount, 0) AS amount,
+  COALESCE(s.cogs, 0) AS cogs,
+  COALESCE(s.packaging, 0) AS packaging,
+  COALESCE(s.cashback, 0) AS cashback,
+  COALESCE(s.tax_paid_usd, 0) AS tax_paid_usd,
+  COALESCE(s.gateway_fees, 0) AS gateway_fees,
+  COALESCE(s.refunds, 0) AS refunds,
+  COALESCE(s.n_orders, 0) AS n_orders,
+
+  -- Cost lines from other sources
+  COALESCE(d.delivery_cost, 0) AS delivery_cost,
+  COALESCE(m.marketing_cost, 0) AS marketing_cost,
+  COALESCE(o.teleconsultation_fees, 0) AS teleconsultation_fees,
+  COALESCE(o.dispensing_fees, 0) AS dispensing_fees,
+  COALESCE(o.operating_expense, 0) AS operating_expense,
+  COALESCE(o.staff_cost, 0) AS staff_cost,
+
+  -- Derived margin calculations
+  COALESCE(s.amount, 0) AS gross_revenue,
+  -- Net revenue: revenue net of refunds and tax
+  COALESCE(s.amount, 0) - COALESCE(s.refunds, 0) - COALESCE(s.tax_paid_usd, 0) AS net_revenue,
+  -- Gross profit: net revenue minus COGS and dispensing
+  COALESCE(s.amount, 0) - COALESCE(s.refunds, 0) - COALESCE(s.tax_paid_usd, 0)
+    - COALESCE(s.cogs, 0) - COALESCE(o.dispensing_fees, 0) AS gross_profit,
+  -- Contribution Margin 2 (CM2): after gross profit, subtract packaging, delivery, gateway
+  COALESCE(s.amount, 0) - COALESCE(s.refunds, 0) - COALESCE(s.tax_paid_usd, 0)
+    - COALESCE(s.cogs, 0) - COALESCE(o.dispensing_fees, 0)
+    - COALESCE(s.packaging, 0) - COALESCE(d.delivery_cost, 0) - COALESCE(s.gateway_fees, 0) AS cm2,
+  -- Contribution Margin 3 (CM3): CM2 minus marketing cost
+  COALESCE(s.amount, 0) - COALESCE(s.refunds, 0) - COALESCE(s.tax_paid_usd, 0)
+    - COALESCE(s.cogs, 0) - COALESCE(o.dispensing_fees, 0)
+    - COALESCE(s.packaging, 0) - COALESCE(d.delivery_cost, 0) - COALESCE(s.gateway_fees, 0)
+    - COALESCE(m.marketing_cost, 0) AS cm3,
+  -- EBITDA: CM3 minus all OPEX
+  COALESCE(s.amount, 0) - COALESCE(s.refunds, 0) - COALESCE(s.tax_paid_usd, 0)
+    - COALESCE(s.cogs, 0) - COALESCE(o.dispensing_fees, 0)
+    - COALESCE(s.packaging, 0) - COALESCE(d.delivery_cost, 0) - COALESCE(s.gateway_fees, 0)
+    - COALESCE(m.marketing_cost, 0)
+    - COALESCE(o.operating_expense, 0)
+    - COALESCE(o.staff_cost, 0) AS ebitda
+
+FROM all_keys AS k
+LEFT JOIN sales_agg AS s 
+	ON k.date = s.date 
+	AND k.country = s.country 
+	AND k.condition = s.condition
+LEFT JOIN marketing_agg AS m 
+	ON k.date = m.date 
+	AND k.country = m.country 
+	AND k.condition = m.condition
+LEFT JOIN delivery_agg AS d 
+	ON k.date = d.date 
+	AND k.country = d.country 
+	AND k.condition = d.condition
+LEFT JOIN opex_agg AS o 
+	ON k.date = o.date 
+ 	AND k.country = o.country 
+ 	AND k.condition = o.condition
+;


### PR DESCRIPTION
Rewrites the monthly_contribution_margin view to use clearer, modular CTEs for sales, marketing, delivery, and opex aggregations. Introduces an 'all_keys' CTE to ensure all combinations of date, country, and condition are present, and aligns all sources via LEFT JOINs for comprehensive reporting. Improves field standardization, adds comments, and simplifies margin calculations for maintainability and accuracy.