### PR TITLE
WFOF-242 Add queries for missing country codes in ad data

### DIFF
--- a/facebook_ads_missing_country_codes.sql
+++ b/facebook_ads_missing_country_codes.sql
@@ -1,0 +1,24 @@
+WITH fb_ash AS (
+	SELECT *
+	FROM facebook_ads.ad_set_history
+	QUALIFY ROW_NUMBER() OVER(PARTITION BY id ORDER BY updated_time DESC) = 1
+),
+
+fb_ad_history AS (
+	SELECT *
+	FROM facebook_ads.ad_history
+	QUALIFY ROW_NUMBER() OVER(PARTITION BY id ORDER BY updated_time DESC) = 1
+
+)
+
+SELECT DISTINCT
+	d.campaign_name,
+	d.ad_id
+FROM facebook_ads.basic_all_levels AS d
+LEFT JOIN fb_ad_history
+	ON CAST(d.ad_id AS STRING) = CAST(fb_ad_history.id AS STRING)
+LEFT JOIN fb_ash AS ash
+    ON CAST(fb_ad_history.ad_set_id AS STRING) = CAST(ash.id AS STRING)
+WHERE
+    (d.reach > 0 OR d.ctr > 0 or d.spend > 0)
+    AND REGEXP_REPLACE(ash.targeting_geo_locations_countries, r'[\[\]"]', '') IS NULL

--- a/google_ads_missing_countries.sql
+++ b/google_ads_missing_countries.sql
@@ -1,0 +1,37 @@
+
+WITH ga_targeting AS (
+	SELECT
+		campaign_id,
+		geo_target_constant_id
+	FROM google_ads.campaign_criterion_history
+	WHERE 
+		geo_target_constant_id IS NOT NULL
+	QUALIFY ROW_NUMBER() OVER (PARTITION BY campaign_id ORDER BY updated_at DESC) = 1
+),
+
+
+google_campaigns AS (
+	SELECT
+		ch.id,
+		ch.name
+	FROM google_ads.campaign_history AS ch
+	QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY ch.updated_at DESC) = 1
+),
+
+google_ad_history AS (
+	SELECT *
+	FROM google_ads.ad_history
+	QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY updated_at DESC) = 1
+)
+
+SELECT DISTINCT
+	google_campaigns.name,
+	s.id
+FROM google_ads.campaign_stats AS s
+LEFT JOIN ga_targeting AS c
+	ON s.id = c.campaign_id
+LEFT JOIN google_campaigns
+	ON s.id = google_campaigns.id
+LEFT JOIN google_ads.geo_target AS g
+	ON c.geo_target_constant_id = g.id
+WHERE g.country_code IS NULL

--- a/vw_marketing_spend.sql
+++ b/vw_marketing_spend.sql
@@ -91,7 +91,12 @@ SELECT
 	d.campaign_name,
 	ccm.condition,
 	a.currency AS currency_code,
-    REGEXP_REPLACE(ash.targeting_geo_locations_countries, r'[\[\]"]', '') AS country_code,
+    COALESCE(
+    	REGEXP_REPLACE(ash.targeting_geo_locations_countries, r'[\[\]"]', ''),
+    	JSON_VALUE(ash.targeting_geo_locations_cities, '$[0].country'),
+    	JSON_VALUE(ash.targeting_geo_locations_regions, '$[0].country'),
+    	JSON_VALUE(ash.targeting_geo_locations_custom_locations, '$[0].country')
+    ) AS country_code,
 	SUM(d.reach) AS reach,
 	SUM(d.ctr * d.impressions / 100) AS clicks,
 	SUM(d.impressions) AS impressions,


### PR DESCRIPTION
Added SQL scripts to identify Facebook and Google ads missing country or country code information. Updated vw_marketing_spend.sql to improve country code extraction by using fallback fields when the main country code is missing.