### PR TITLE
WFOF-4 Add patient_id to all_appointments view

### DIFF
--- a/vw_all_appointments_new.sql
+++ b/vw_all_appointments_new.sql
@@ -7,6 +7,7 @@ CREATE VIEW all_postgres.all_appointments AS (
 		cs.consultation_session_type,
 		o.short_id AS order_short_id,
 		cs.order_sys_id,
+		o.patient_id,
 		cs.consultation_session_status,
 		cs.progress_status,
 		ca.consult_type,


### PR DESCRIPTION
Included the patient_id field from the orders table in the all_appointments view to provide direct access to patient identifiers in appointment queries.