### PR TITLE
WFOF-4 Join consults with customer_acq on patient and date

### DIFF
--- a/vw_marketing_cost_per_action.sql
+++ b/vw_marketing_cost_per_action.sql
@@ -91,6 +91,9 @@ consults AS (
 		COALESCE(a.condition, 'N/A') AS condition,
 		COUNT(DISTINCT a.consult_sys_id) AS n
 	FROM all_postgres.all_appointments AS a
+	INNER JOIN customer_acq AS ca
+		ON a.patient_id = ca.patient_id
+		AND a.date <= DATE_ADD(ca.acquisition_date, INTERVAL 7 DAY)
 	GROUP BY 1,2,3,4
 ),
 


### PR DESCRIPTION
Added an INNER JOIN between all_appointments and customer_acq in the consults CTE to ensure only appointments within 7 days of acquisition_date are included. This refines the consults data to better align with acquisition timing.