### PR TITLE
WFOF-256 Standardise brand formatting and handling across SQL views; …

### DIFF
--- a/vw_contribution_margin.sql
+++ b/vw_contribution_margin.sql
@@ -12,7 +12,7 @@ WITH sub_starts AS (
 patient_brand_stripe_ids AS (
 	SELECT DISTINCT
 		stripe_customer_id,
-		from_platform_env AS brand
+		INITCAP(from_platform_env) AS brand
 	FROM all_postgres.patient
 ),
 
@@ -350,7 +350,7 @@ atome_final AS (
 			ELSE 'One-Time' 
 			END AS purchase_type,
 		'manual' AS billing_reason,
-		p.from_platform_env AS brand,
+		INITCAP(p.from_platform_env) AS brand,
 		o.patient_id AS customer_id,
 		p.email,
 		am.atome_order_id AS charge_id,

--- a/vw_daily_roas.sql
+++ b/vw_daily_roas.sql
@@ -37,8 +37,12 @@ all_keys AS (
 			ELSE 'N/A'
 			END AS condition,
 		region AS country,
-		brand
+		COALESCE(brand, 'N/A') AS brand
 	FROM finance_metrics.contribution_margin
+	WHERE
+		1 = 1
+		AND COALESCE(line_item_amount_usd, total_charge_amount_usd) > 0
+
 )
 
 
@@ -56,7 +60,7 @@ SELECT
 FROM all_keys AS k
 LEFT JOIN finance_metrics.contribution_margin AS cm
 	ON k.date = cm.purchase_date
-	AND k.brand = cm.brand
+	AND k.brand = COALESCE(cm.brand, 'N/A')
 	AND k.condition = (
 		CASE 
 			WHEN cm.condition IN ('ED', 'PE') THEN 'ED + PE'

--- a/vw_marketing_spend.sql
+++ b/vw_marketing_spend.sql
@@ -152,7 +152,7 @@ UNION ALL
 
 SELECT
 	man.supplier AS channel,
-	'N/A - Manual Ad Spend' AS brand,
+	'N/A' AS brand,
 	man.date,
 	CAST(NULL AS STRING) AS campaign_name,
 	man.condition, 


### PR DESCRIPTION
…ensure consistency for null and manual entries.

his commit introduces several improvements to the way the brand field is handled and formatted across multiple SQL views (vw_contribution_margin.sql, vw_daily_roas.sql, and vw_marketing_spend.sql). The changes ensure consistency in data presentation and handling of missing or manually-specified brands.

⸻

Detailed Changes

vw_contribution_margin.sql
	•	Brand Formatting:
	•	Updated brand field derivation in both the patient_brand_stripe_ids CTE and within atome_final to use INITCAP(from_platform_env). This standardises the brand values by capitalising the first letter, ensuring consistent naming conventions throughout the dataset.

vw_daily_roas.sql
	•	Null Handling for Brand:
	•	Modified the brand field to use COALESCE(brand, 'N/A') AS brand, replacing null or missing brand values with 'N/A'. This prevents blank entries and makes downstream reporting and filtering more robust.
	•	Join Condition Consistency:
	•	Updated join condition to match on COALESCE(cm.brand, 'N/A'), aligning with the new null handling logic and ensuring all relevant records are included even when brand information is missing.

vw_marketing_spend.sql
	•	Manual Brand Labelling:
	•	Replaced 'N/A - Manual Ad Spend' with a simpler 'N/A' label for manual ad spend entries, promoting consistency with the brand handling updates in other views.