### PR TITLE
WFOF-257 Add purchase volume and marketing thresholds to metrics view

### DIFF
--- a/vw_facebook_daily_campaign_metrics.sql
+++ b/vw_facebook_daily_campaign_metrics.sql
@@ -4,8 +4,7 @@
 -- This query creates a comprehensive report combining Facebook Ads spend data 
 -- with purchase revenue, normalized to USD using foreign exchange rates.
 -- CTE 1: Get the latest campaign information and conditions
-WITH
-	campaigns AS (
+WITH campaigns AS (
 		SELECT
 			CAST(ch.id AS STRING) AS campaign_id, -- Convert campaign ID to string for consistent joins
 			ch.name AS campaign_name, -- Campaign display name
@@ -35,10 +34,9 @@ WITH
 			CAST(id AS STRING) AS account_id,
 			currency, -- Account currency for FX conversion
 			SPLIT(name, ' ') [OFFSET(0)] AS brand -- Extract brand name (first word of account name)
-		FROM
-			facebook_ads.account_history
+		FROM facebook_ads.account_history
 		-- Get the most recent account information (using created_time as proxy for latest)
-		QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY updated_time DESC) = 1
+		QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY _fivetran_synced DESC) = 1
 	),
 	-- CTE 4: Get ad set targeting information (geographic and audience targeting)
 	targeting AS (
@@ -59,7 +57,20 @@ WITH
 			AND aav.action_type = 'purchase' -- Only include actual purchases (not other actions)
 		GROUP BY 1, 2
 	),
-	-- CTE 6: Aggregate spend by ad and date
+	
+	-- CTE 6: Aggregate purchase volume by ad and date
+	purchases AS (
+		SELECT
+			CAST(ad_id AS STRING) AS ad_id, -- Ad that generated the revenue
+			date, -- Date of the purchase
+			SUM(value) AS total_purchase_volume -- Sum all purchase values for the ad/date
+		FROM facebook_ads.basic_ad_actions
+		WHERE
+			1 = 1 -- Placeholder for additional filters
+			AND action_type = 'purchase' -- Only include actual purchases (not other actions)
+		GROUP BY 1, 2
+	),
+	-- CTE 7: Aggregate spend by ad and date
 	spend AS (
 		SELECT
 			CAST(ba.ad_id AS STRING) AS ad_id, -- Ad that incurred the spend
@@ -88,35 +99,47 @@ SELECT
 		JSON_VALUE(targeting.targeting_geo_locations_regions, '$[0].country'), -- Extract country from first region
 		JSON_VALUE(targeting.targeting_geo_locations_custom_locations, '$[0].country') -- Extract country from custom locations
 	) AS country,
-	-- Convert revenue to USD using foreign exchange rates
+	mt.cpr_threshold,
 	-- COALESCE handles cases where there's no revenue data (sets to 0)
+	SUM(COALESCE(p.total_purchase_volume, 0)) AS purchase_volume,
 	SUM(COALESCE(r.total_purchase_revenue / fx.fx_to_usd, 0)) AS purchase_revenue,
 	-- Convert spend to USD using foreign exchange rates
 	SUM(s.total_spend / fx.fx_to_usd) AS spend
 FROM spend AS s -- Start with spend data as the base
+
 -- Left join revenue to include spend records even without corresponding revenue
 LEFT JOIN revenue AS r 
-	ON r.ad_id = s.ad_id
-	AND r.date = s.date -- Match on both ad and date for accuracy
+	ON s.ad_id = r.ad_id
+	AND s.date = r.date
+
+LEFT JOIN purchases AS p
+	ON s.ad_id = p.ad_id
+	AND s.date = p.date
+
 -- Inner join ads to get campaign/ad set hierarchy (required for targeting info)
 INNER JOIN ads 
 	ON s.ad_id = ads.ad_id
 	-- Left join targeting to get geographic and audience information
 LEFT JOIN targeting 
 	ON ads.ad_set_id = CAST(targeting.id AS STRING)
+
 -- Left join campaigns to get campaign-level information and conditions
-LEFT JOIN campaigns c 
+LEFT JOIN campaigns AS c 
 	ON ads.campaign_id = c.campaign_id
-	-- Left join accounts to get brand and currency information
+
+-- Left join accounts to get brand and currency information
 LEFT JOIN accounts 
 	ON c.account_id = accounts.account_id
+
 -- Left join FX rates to convert local currency to USD
 -- Uses case-insensitive matching for currency codes
 LEFT JOIN ref.fx_rates AS fx 
 	ON LOWER(accounts.currency) = LOWER(fx.currency)
+	
+LEFT JOIN google_sheets.marketing_thresholds AS mt
+	ON c.condition = mt.condition	
 WHERE
 	1 = 1
 	AND s.total_spend > 0 -- Only include records with actual spend (exclude $0 spend days)
 
--- Group by all non-aggregated columns to enable SUM operations
-GROUP BY1,2,3,4,5,6
+GROUP BY 1,2,3,4,5,6,7


### PR DESCRIPTION
Introduced a new CTE to aggregate purchase volume by ad and date, and joined marketing thresholds from Google Sheets. Updated group by and select statements to include purchase volume and cpr_threshold, and fixed account history join to use the correct sync timestamp.