### PR TITLE
WFOF-262 Add view for OTC price ID extraction

### DIFF
--- a/vw_otc_price_id.sql
+++ b/vw_otc_price_id.sql
@@ -1,0 +1,35 @@
+DROP VIEW IF EXISTS all_stripe.otc_price_id;
+CREATE VIEW all_stripe.otc_price_id AS
+
+WITH extracted AS (
+  SELECT
+    id AS payment_intent_id,
+    description,
+    REGEXP_EXTRACT_ALL(description, r'price-([a-zA-Z0-9]+)\)\s*x\s*(\d+)') AS raw_matches
+  FROM all_stripe.payment_intent
+),
+unnested AS (
+  SELECT
+    payment_intent_id,
+    description,
+    REPLACE(SPLIT(match, ') x ')[OFFSET(0)], '-', '_') AS price_id,
+    SAFE_CAST(SPLIT(match, ') x ')[OFFSET(1)] AS INT64) AS quantity
+  FROM extracted,
+  UNNEST(REGEXP_EXTRACT_ALL(description, r'price-[a-zA-Z0-9]+\)\s*x\s*\d+')) AS match
+)
+SELECT 
+	u.*,
+	px.currency,
+	px.unit_amount / fx.fx_to_usd / COALESCE(sub.subunits, 100) AS amount_usd,
+	pr.name AS product_name,
+	JSON_VALUE(pr.metadata, '$.condition') AS condition
+FROM unnested AS u
+LEFT JOIN all_stripe.price AS px
+	ON u.price_id = LOWER(px.id)
+LEFT JOIN all_stripe.product AS pr
+	ON px.product_id = pr.id
+LEFT JOIN ref.fx_rates AS fx
+	ON px.currency = fx.currency
+LEFT JOIN ref.stripe_currency_subunits AS sub
+	ON px.currency = sub.currency
+;


### PR DESCRIPTION
Introduces the all_stripe.otc_price_id view to extract price IDs and quantities from payment intent descriptions, join with price and product metadata, and calculate USD amounts. This view facilitates easier analysis of OTC pricing data.