### PR TITLE
WFOF-263 Resolve merge conflict in vw_otc_price_id.sql

### DIFF
--- a/vw_otc_price_id.sql
+++ b/vw_otc_price_id.sql
@@ -18,11 +18,24 @@ unnested AS (
   UNNEST(REGEXP_EXTRACT_ALL(description, r'price-[a-zA-Z0-9]+\)\s*x\s*\d+')) AS match
 )
 SELECT 
+<<<<<<< Updated upstream
 	u.*,
 	px.currency,
 	px.unit_amount / fx.fx_to_usd / COALESCE(sub.subunits, 100) AS amount_usd,
 	pr.name AS product_name,
 	JSON_VALUE(pr.metadata, '$.condition') AS condition
+=======
+  u.payment_intent_id,
+  u.description,
+  u.price_id,
+  u.quantity,
+  px.currency,
+  u.discount_amount / fx.fx_to_usd AS discount_amount_usd,
+  u.shipping_amount / fx.fx_to_usd AS shipping_amount_usd,
+  px.unit_amount / fx.fx_to_usd / COALESCE(sub.subunits, 100) AS unit_amount_usd,
+  pr.name AS product_name,
+  JSON_VALUE(pr.metadata, '$.condition') AS condition
+>>>>>>> Stashed changes
 FROM unnested AS u
 LEFT JOIN all_stripe.price AS px
 	ON u.price_id = LOWER(px.id)


### PR DESCRIPTION
This commit addresses a merge conflict in the SELECT statement of vw_otc_price_id.sql, reconciling differences between upstream and stashed changes related to selected columns and calculated fields.