### PR TITLE
WFOF-269 Add state and city to patient query results

### DIFF
--- a/jp_demo_query.sql
+++ b/jp_demo_query.sql
@@ -1,5 +1,7 @@
 SELECT DISTINCT 
 	p.sys_id AS patient_id,
+	add.state,
+	add.city,
 	REGEXP_REPLACE(
 		REGEXP_REPLACE(add.postal, r'[^0-9]', ''),  -- remove non-digits
   		r'^(\d{3})(\d{4})$',                        -- split into two groups
@@ -15,4 +17,4 @@ INNER JOIN jp_postgres_rds_public.patient AS p
 	ON cm.customer_id = p.stripe_customer_id
 LEFT JOIN jp_postgres_rds_public.address AS add
 	ON p.deliveryaddresssysid = add.sys_id
-GROUP BY 1,2,3,4,5,6
+GROUP BY 1,2,3,4,5,6,7,8


### PR DESCRIPTION
The query now includes the state and city fields from the address table in the SELECT statement and updates the GROUP BY clause accordingly to support these new columns.