### PR TITLE
WFOF-246 Refactor interval logic to use days instead of counts

### DIFF
--- a/subscription_interval_changes.sql
+++ b/subscription_interval_changes.sql
@@ -1,37 +1,46 @@
 
 -- Step 1: Create a Common Table Expression (CTE) called 'all_intervals'
-WITH all_intervals AS (
+WITH all_intervals_daily AS (
     SELECT DISTINCT
         UPPER(sh.region) AS country,                         -- Normalize country/region to uppercase
         sh.id AS subscription_id,                            -- Subscription ID
+        sh._fivetran_start,
         sh.status,                                           -- Subscription status (active, canceled, etc.)
         DATE(sh.created) AS subscription_created,            -- Date the subscription was created
         DATE(sh._fivetran_start) AS subscription_updated,    -- Update timestamp from Fivetran
         p.product_id,                                        -- Product ID
         prod.name AS product_name,                           -- Product name
-        JSON_EXTRACT_SCALAR(prod.metadata, '$.condition') AS condition, -- Extract 'condition' from product JSON metadata
-        p.interval_count AS current_interval_count,           -- Bill interval (e.g., monthly count)
-        
-        -- Previous interval count for this subscription/product pair
-        LAG(p.interval_count) OVER (
-            PARTITION BY sh.id, p.product_id
-            ORDER BY sh._fivetran_start
-        ) AS previous_interval_count,
-
-        -- First recorded interval count in the history for this subscription/product
-        FIRST_VALUE(p.interval_count) OVER (
-            PARTITION BY sh.id, p.product_id
-            ORDER BY sh._fivetran_start
-        ) AS first_interval_count
-
+        JSON_VALUE(prod.metadata, '$.condition') AS condition, -- Extract 'condition' from product JSON metadata
+        CASE
+    		WHEN p.interval = 'day' THEN p.interval_count
+    		WHEN p.interval = 'week' THEN p.interval_count * 7
+    		WHEN p.interval = 'month' THEN p.interval_count * 30
+    		WHEN p.interval = 'year' THEN p.interval_count * 365
+    		END AS current_interval_days
     FROM all_stripe.subscription_history AS sh
     JOIN all_stripe.invoice_line_item AS ili 
         ON sh.latest_invoice_id = ili.invoice_id                -- Link subscription to its most recent invoice
     JOIN all_stripe.plan AS p 
         ON ili.plan_id = p.id                                   -- Link invoice line to plan
-        AND p.interval = 'month'                                -- Only consider plans billed monthly
     JOIN all_stripe.product AS prod
         ON p.product_id = prod.id                               -- Link plan to product
+),
+
+all_intervals AS (
+	SELECT 
+		aid.*,
+        -- Previous interval count for this subscription/product pair
+        LAG(aid.current_interval_days) OVER (
+            PARTITION BY aid.subscription_id, aid.product_id
+            ORDER BY aid._fivetran_start
+        ) AS previous_interval_days,
+
+        -- First recorded interval count in the history for this subscription/product
+        FIRST_VALUE(aid.current_interval_days) OVER (
+            PARTITION BY aid.subscription_id, aid.product_id
+            ORDER BY aid._fivetran_start
+        ) AS first_interval_days
+	FROM all_intervals_daily AS aid
 ),
 
 -- Step 2: Find the first qualifying active subscription interval for each subscription-product pair
@@ -40,7 +49,7 @@ first_interval AS (
     FROM all_intervals
     WHERE
         1 = 1                       -- Dummy condition for easier commenting/editing
-        AND first_interval_count <= 3   -- Only consider if the original interval count was 3 or less
+        AND first_interval_days <= 90   -- Only consider if the original interval count was <= 90 days
         AND status = 'active'           -- Only active subscriptions
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY subscription_id, product_id
@@ -57,13 +66,13 @@ SELECT
     fi.product_id,                                    -- Product ID
     fi.product_name,                                  -- Product name
     fi.condition,                                     -- Product 'condition' metadata
-    fi.first_interval_count,                          -- Original interval count (<= 3)
-    ai.current_interval_count,                        -- The upgraded interval count (> 3)
+    fi.first_interval_days,                          -- Original interval count (<= 90 days)
+    ai.current_interval_days,                        -- The upgraded interval count (> 90 days)
     DATE_DIFF(ai.subscription_updated, ai.subscription_created, DAY) AS days_elapsed -- Days from start to upgrade
 FROM first_interval AS fi
 LEFT JOIN all_intervals AS ai
     ON fi.subscription_id = ai.subscription_id
     AND fi.product_id = ai.product_id
-    AND ai.current_interval_count > ai.previous_interval_count         -- Only true upgrades
-    AND ai.current_interval_count > 3                                 -- Only upgrades beyond 3
+    AND ai.current_interval_days > ai.previous_interval_days         -- Only true upgrades
+    AND ai.current_interval_days > 90                                 -- Only upgrades beyond days
     AND DATE_DIFF(ai.subscription_updated, ai.subscription_created, DAY)  <= 90 -- Upgrade must occur within 90 days


### PR DESCRIPTION
Changed interval calculations to consistently use days rather than raw interval counts, supporting day, week, month, and year intervals. Updated filtering and window functions to reflect the new logic, improving flexibility and accuracy for subscriptions with non-monthly billing intervals.