### PR TITLE
WFOF-271 Add survey and patient evaluation SQL views

### DIFF
--- a/survey_hearus.sql
+++ b/survey_hearus.sql
@@ -1,0 +1,18 @@
+SELECT
+	s.region,
+	DATE(s.created_at) AS date_created,
+	s.ordersysid,
+	ev.name,
+	ev.platform,
+	ev.type,
+	JSON_VALUE(item, '$.key') AS answer
+FROM all_postgres.survey AS s
+CROSS JOIN UNNEST(JSON_QUERY_ARRAY(answers)) AS item
+LEFT JOIN all_postgres.order AS o
+	ON s.ordersysid = o.sys_id
+LEFT JOIN all_postgres.evaluation AS ev
+	ON o.evaluation_id = ev.sys_id 
+WHERE 
+	1 = 1
+	AND s.type = 'HearUs'
+	AND s.answers IS NOT NULL

--- a/vw_all_postgres_patient_evaluation.sql
+++ b/vw_all_postgres_patient_evaluation.sql
@@ -1,0 +1,21 @@
+DROP VIEW IF EXISTS all_postgres.patient_evaluation;
+CREATE VIEW all_postgres.patient_evaluation AS 
+
+SELECT 
+	'sg' AS region,
+	sg.* 
+FROM sg_postgres_rds_public.patient_evaluation AS sg
+
+UNION ALL
+
+SELECT 
+	'hk' AS region,
+	hk.* 
+FROM hk_postgres_rds_public.patient_evaluation AS hk
+
+UNION ALL
+
+SELECT 
+	'jp' AS region,
+	jp.* 
+FROM jp_postgres_rds_public.patient_evaluation AS jp;


### PR DESCRIPTION
Introduces survey_hearus.sql to extract HearUs survey data and vw_all_postgres_patient_evaluation.sql to create a unified patient_evaluation view across SG, HK, and JP regions.