### PR TITLE
Part of WFOF-286. Expand price_id matching in contribution margin view

### DIFF
--- a/vw_contribution_margin.sql
+++ b/vw_contribution_margin.sql
@@ -115,7 +115,15 @@ stripe_data AS (
 		AND ch.invoice_id IS NULL -- ONLY for OTC charges which have no invoice_id
 	
 	LEFT JOIN all_stripe.price AS px
-		ON LOWER(COALESCE(ii.price_id, otc.price_id)) = LOWER(px.id) -- need LOWER() because price_ids extracted from otc payment_intent metadata are all lowercase
+		ON LOWER(
+			COALESCE(
+				ii.price_id, 
+				otc.price_id, 
+				JSON_VALUE(pi.metadata, '$.priceIds'),
+				JSON_VALUE(pi.metadata, '$.stripePriceIds'),
+				JSON_VALUE(pi.metadata, '$.paymentIntentPriceId')
+			)
+		) = LOWER(px.id) -- need LOWER() because price_ids extracted from otc payment_intent metadata are all lowercase
 	LEFT JOIN all_stripe.product AS prod
 		ON px.product_id = prod.id
 	


### PR DESCRIPTION
Updated the LEFT JOIN condition to include additional metadata fields (priceIds, stripePriceIds, paymentIntentPriceId) when matching price_id, improving robustness for OTC charges with varied metadata formats.