### PR TITLE
Part of WFOF-288. Add new/existing customer flag to subscription history

### DIFF
--- a/all_subscription_history.sql
+++ b/all_subscription_history.sql
@@ -119,7 +119,7 @@ SELECT
 	aswm.subscription_id,
 	aswm.customer_id,
 	CASE 
-		WHEN fp.first_purchase_date <= aswm.created_at THEN 'Existing'
+		WHEN fp.first_purchase_date < aswm.created_at THEN 'Existing'
 		ELSE 'New'
 		END AS new_existing,
 	cal.obs_date,


### PR DESCRIPTION
Introduced a first_purchase CTE to determine each customer's first purchase date and added a 'new_existing' field in the final SELECT to flag subscriptions as 'New' or 'Existing' based on whether the first purchase date is after the subscription creation date.