### PR TITLE
Fixes WFOF-302. Add daily CAC SQL query

### DIFF
--- a/daily_cac.sql
+++ b/daily_cac.sql
@@ -1,0 +1,30 @@
+WITH marketing AS (
+	SELECT
+		date,
+		UPPER(country_code) AS country,
+		SUM(cost_usd) AS marketing_spend
+	FROM cac.marketing_spend
+	GROUP BY 1,2
+),
+
+acq_dates AS (
+	SELECT
+		sh.region,
+		sh.customer_id,
+		MIN(sh.obs_date) AS acquired_date
+	FROM all_stripe.subscription_metrics AS sh
+	WHERE 
+		sh.mrr_usd > 0
+	GROUP BY 1,2
+)
+
+SELECT
+	mar.date,
+	mar.country,
+	mar.marketing_spend,
+	COUNT(DISTINCT ad.customer_id) AS n_new_customers
+FROM marketing AS mar
+LEFT JOIN acq_dates AS ad
+	ON DATE(mar.date) = DATE(ad.acquired_date)
+	AND LOWER(mar.country) = LOWER(ad.region)
+GROUP BY 1,2,3


### PR DESCRIPTION
Introduces a new SQL script to calculate daily customer acquisition cost (CAC) by joining marketing spend with new customer acquisition data, grouped by date and country. Only counts subscription customers