### PR TITLE
Part of WFOF-306. Add condition field and update margin query filters

### DIFF
--- a/vw_customer_lifecycle_monthly.sql
+++ b/vw_customer_lifecycle_monthly.sql
@@ -12,6 +12,7 @@ WITH customers_monthly AS (
             -- Otherwise keep first of month
             ELSE DATE_TRUNC(obs_date, MONTH)
         END AS obs_date,
+        condition,
         mrr_usd AS mrr_usd
     FROM all_stripe.subscription_metrics
     WHERE

--- a/vw_customer_ltv_cac_latest.sql
+++ b/vw_customer_ltv_cac_latest.sql
@@ -92,7 +92,9 @@ gm_month AS (
 	FROM finance_metrics.monthly_contribution_margin gm
 	WHERE
 		-- first day of prior month
-  		gm.date = DATE_SUB(DATE_TRUNC(CURRENT_DATE(), MONTH), INTERVAL 1 MONTH) 
+  		1 = 1
+  		AND gm.date = DATE_TRUNC(CURRENT_DATE(), MONTH)
+  		AND (gm.condition IS NULL OR gm.condition <> 'Services')
 	GROUP BY 1,2
 ),
 


### PR DESCRIPTION
Added the 'condition' field to vw_customer_lifecycle_monthly.sql for enhanced data granularity. Updated vw_customer_ltv_cac_latest.sql to filter monthly contribution margin by current month and exclude 'Services' condition, improving accuracy of LTV/CAC calculations.